### PR TITLE
 Avoid positional arguments to define-minor-mode

### DIFF
--- a/extension/latex/popweb-latex.el
+++ b/extension/latex/popweb-latex.el
@@ -158,7 +158,7 @@
 ;;;###autoload
 (define-minor-mode popweb-latex-mode
   "Toggle popweb-latex-mode"
-  nil nil nil
+  :group 'popweb-latex
   (if popweb-latex-mode
       (progn
         (setq popweb-latex-current-buffer (current-buffer))


### PR DESCRIPTION
Get rid of the warning "Use keywords rather than deprecated positional arguments to define-minor-mode" in Emacs 29