### PR TITLE
Improve popweb-server check

### DIFF
--- a/popweb.el
+++ b/popweb.el
@@ -93,7 +93,7 @@
 
 (defun popweb--start-epc-server ()
   "Function to start the EPC server."
-  (unless popweb-server
+  (unless (process-live-p popweb-server)
     (setq popweb-server
           (popweb-epc-server-start
            (lambda (mngr)


### PR DESCRIPTION
If I kill the popweb server manual, popweb-server is not empty. Check the process live or not to avoid the issue.