### PR TITLE
feat: Added an extension to preview arbitrary URLs

### DIFF
--- a/extension/url-preview/popweb-url.el
+++ b/extension/url-preview/popweb-url.el
@@ -1,0 +1,81 @@
+;;; Require
+(require 'popweb)
+
+(setq popweb-url-module-path (concat (file-name-directory load-file-name) "popweb-url.py"))
+
+(defvar popweb-url-web-window-visible-p nil)
+
+
+(defun popweb-url-local-file-url-completion (current-line)
+  "If url is local file, complete it's absolute path"
+  (let ((match-result (match-string 0 current-line))
+        (current-path (when (buffer-file-name)
+                        (file-name-directory (buffer-file-name)))))
+        (replace-regexp-in-string "^file:" (concat "file:" current-path) match-result)))
+
+
+
+(defun popweb-current-line-url ()
+  "Return current line url."
+  (let ((current-line (thing-at-point 'line t)))
+    (when (string-match gnus-button-url-regexp current-line)
+      (popweb-url-local-file-url-completion current-line))))
+
+
+(defun popweb-url-prompt-input (prompt)
+  "Prompt input url for preview ."
+  (read-string (format "%s(%s): " prompt (or (popweb-current-line-url) ""))
+               nil nil
+               (popweb-current-line-url)))
+
+(defun popweb-url-web-window-hide-after-move ()
+  "Hide popweb window after move"
+  (when (and popweb-url-web-window-visible-p (popweb-epc-live-p popweb-epc-process))
+    (popweb-call-async "hide_web_window" "url-preview")
+    (setq popweb-url-web-window-visible-p nil)
+    (remove-hook 'post-command-hook #'popweb-dict-bing-web-window-hide-after-move)))
+
+(defun popweb-url (info)
+  "Pop window to show current url preview"
+  (let* ((position (popweb-get-cursor-coordinate))
+         (x (car position))
+         (y (cdr position))
+         (x-offset (popweb-get-cursor-x-offset))
+         (y-offset (popweb-get-cursor-y-offset))
+         (frame-x (car (frame-position)))
+         (frame-y (cdr (frame-position)))
+         (frame-w (frame-outer-width))
+         (frame-h (frame-outer-height))
+         (width-scale 0.35)
+         (height-scale 0.5)
+         (url (nth 0 info))
+         )
+    (popweb-call-async "call_module_method" popweb-url-module-path
+                       "pop_url_window"
+                       (list
+                        "url-preview"
+                        x y x-offset y-offset
+                        frame-x frame-y frame-w frame-h
+                        width-scale height-scale
+                        url))
+    (popweb-url-web-window-can-hide)))
+
+
+(defun popweb-url-input (&optional url)
+  "Input url for preview"
+  (interactive)
+  (popweb-start 'popweb-url (list (or url (popweb-url-prompt-input "preview url: "))))
+  (add-hook 'post-command-hook #'popweb-url-web-window-hide-after-move))
+
+(defun popweb-url-preview-pointer()
+  "Input url for preview"
+  (interactive)
+  (popweb-start 'popweb-url (list (popweb-current-line-url)))
+  (add-hook 'post-command-hook #'popweb-url-web-window-hide-after-move))
+
+
+(defun popweb-url-web-window-can-hide ()
+  (run-with-timer 1 nil (lambda () (setq popweb-url-web-window-visible-p t))))
+
+
+(provide 'popweb-url)

--- a/extension/url-preview/popweb-url.py
+++ b/extension/url-preview/popweb-url.py
@@ -1,0 +1,13 @@
+from PyQt6.QtCore import QUrl
+
+def pop_url_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url):
+    web_window = popweb.get_web_window(module_name)
+    window_width = frame_w * width_scale
+    window_height = frame_h * height_scale
+    window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
+
+    web_window.webview.load(QUrl(url))
+    web_window.update_theme_mode()
+    web_window.resize(int(window_width), int(window_height))
+    web_window.move(int(window_x), int(window_y))
+    web_window.show()


### PR DESCRIPTION
Added an extension to preview arbitrary URLs

add two command :
1. popweb-url-input
2. popweb-url-preview-pointer

file : current is only support relative path
![image](https://user-images.githubusercontent.com/1028971/172317254-469b6b6a-c23d-4328-b172-668057fb622f.png)

http/https 
![image](https://user-images.githubusercontent.com/1028971/172317524-466746f0-1a09-400d-a33a-a881aaa766e3.png)

