### PR TITLE
Use qtpy to support both PyQt6 and PySide6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ I always wanted a fast and responsive pop-up window to display multimedia conten
 I consider `popweb` to be a sister project, and a lightweight version of EAF that particularly focuses on multimedia popup functionality, some portion of code is shared between the two projects.
 
 ## Installation
-1. Install PyQt6: ```pip install PyQt6 PyQt6-Qt6 PyQt6-sip PyQt6-WebEngine PyQt6-WebEngine-Qt6```
+1. Install qtpy ```pip install qtpy```
+1. Install PyQt6 (or PySide6): ```pip install PyQt6 PyQt6-Qt6 PyQt6-sip PyQt6-WebEngine PyQt6-WebEngine-Qt6```
 2. Install [python-epc](https://github.com/tkf/python-epc): ```pip install epc```
 3. Clone or download this repository (path of the folder is the `<path-to-popweb>` used below).
 4. In your `~/.emacs`, add the following lines:

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt6.QtCore import QUrl
+from qtpy.QtCore import QUrl
 
 def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url, loading_js_code):
     web_window = popweb.get_web_window(module_name)

--- a/extension/latex/popweb-latex.py
+++ b/extension/latex/popweb-latex.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt6.QtCore import QUrl, QTimer
+from qtpy.QtCore import QUrl, QTimer
 import os
 
 def adjust_latex_window(popweb, web_window, window_x, window_y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, show_window, new_latex):

--- a/extension/org-roam/popweb-org-roam-link.py
+++ b/extension/org-roam/popweb-org-roam-link.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from PyQt6.QtCore import QUrl, QTimer
+from qtpy.QtCore import QUrl, QTimer
 import os
 
 

--- a/extension/url-preview/popweb-url.py
+++ b/extension/url-preview/popweb-url.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import QUrl
+from qtpy.QtCore import QUrl
 
 def pop_url_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url):
     web_window = popweb.get_web_window(module_name)

--- a/popweb.el
+++ b/popweb.el
@@ -247,6 +247,151 @@ Turn on this option will improve start speed."
                      popweb-internal-process-prog popweb-internal-process-args)))
       (set-process-query-on-exit-flag popweb-internal-process nil))))
 
+(defun popweb-start-process ()
+  "Start POPWEB process if it isn't started."
+  (unless (popweb-epc-live-p popweb-epc-process)
+    ;; start epc server and set `popweb-server-port'
+    (popweb--start-epc-server)
+    (let* ((popweb-args (append
+                         (list popweb-python-file)
+                         (list (number-to-string popweb-server-port))
+                         )))
+
+      ;; Folow system DPI.
+      (popweb--follow-system-dpi)
+
+      ;; Set process arguments.
+      (if popweb-enable-debug
+          (progn
+            (setq popweb-internal-process-prog "gdb")
+            (setq popweb-internal-process-args (append (list "-batch" "-ex" "run" "-ex" "bt" "--args" popweb-python-command) popweb-args)))
+        (setq popweb-internal-process-prog popweb-python-command)
+        (setq popweb-internal-process-args popweb-args))
+
+      ;; Start python process.
+      (let ((process-connection-type (not (popweb--called-from-wsl-on-windows-p))))
+        (setq popweb-internal-process
+              (apply 'start-process
+                     popweb-name popweb-name
+                     popweb-internal-process-prog popweb-internal-process-args)))
+      (set-process-query-on-exit-flag popweb-internal-process nil))))
+
+(defun popweb-start-process ()
+  "Start POPWEB process if it isn't started."
+  (unless (popweb-epc-live-p popweb-epc-process)
+    ;; start epc server and set `popweb-server-port'
+    (popweb--start-epc-server)
+    (let* ((popweb-args (append
+                         (list popweb-python-file)
+                         (list (number-to-string popweb-server-port))
+                         )))
+
+      ;; Folow system DPI.
+      (popweb--follow-system-dpi)
+
+      ;; Set process arguments.
+      (if popweb-enable-debug
+          (progn
+            (setq popweb-internal-process-prog "gdb")
+            (setq popweb-internal-process-args (append (list "-batch" "-ex" "run" "-ex" "bt" "--args" popweb-python-command) popweb-args)))
+        (setq popweb-internal-process-prog popweb-python-command)
+        (setq popweb-internal-process-args popweb-args))
+
+      ;; Start python process.
+      (let ((process-connection-type (not (popweb--called-from-wsl-on-windows-p))))
+        (setq popweb-internal-process
+              (apply 'start-process
+                     popweb-name popweb-name
+                     popweb-internal-process-prog popweb-internal-process-args)))
+      (set-process-query-on-exit-flag popweb-internal-process nil))))
+
+(defun popweb-start-process ()
+  "Start POPWEB process if it isn't started."
+  (unless (popweb-epc-live-p popweb-epc-process)
+    ;; start epc server and set `popweb-server-port'
+    (popweb--start-epc-server)
+    (let* ((popweb-args (append
+                         (list popweb-python-file)
+                         (list (number-to-string popweb-server-port))
+                         )))
+
+      ;; Folow system DPI.
+      (popweb--follow-system-dpi)
+
+      ;; Set process arguments.
+      (if popweb-enable-debug
+          (progn
+            (setq popweb-internal-process-prog "gdb")
+            (setq popweb-internal-process-args (append (list "-batch" "-ex" "run" "-ex" "bt" "--args" popweb-python-command) popweb-args)))
+        (setq popweb-internal-process-prog popweb-python-command)
+        (setq popweb-internal-process-args popweb-args))
+
+      ;; Start python process.
+      (let ((process-connection-type (not (popweb--called-from-wsl-on-windows-p))))
+        (setq popweb-internal-process
+              (apply 'start-process
+                     popweb-name popweb-name
+                     popweb-internal-process-prog popweb-internal-process-args)))
+      (set-process-query-on-exit-flag popweb-internal-process nil))))
+
+(defun popweb-start-process ()
+  "Start POPWEB process if it isn't started."
+  (unless (popweb-epc-live-p popweb-epc-process)
+    ;; start epc server and set `popweb-server-port'
+    (popweb--start-epc-server)
+    (let* ((popweb-args (append
+                         (list popweb-python-file)
+                         (list (number-to-string popweb-server-port))
+                         )))
+
+      ;; Folow system DPI.
+      (popweb--follow-system-dpi)
+
+      ;; Set process arguments.
+      (if popweb-enable-debug
+          (progn
+            (setq popweb-internal-process-prog "gdb")
+            (setq popweb-internal-process-args (append (list "-batch" "-ex" "run" "-ex" "bt" "--args" popweb-python-command) popweb-args)))
+        (setq popweb-internal-process-prog popweb-python-command)
+        (setq popweb-internal-process-args popweb-args))
+
+      ;; Start python process.
+      (let ((process-connection-type (not (popweb--called-from-wsl-on-windows-p))))
+        (setq popweb-internal-process
+              (apply 'start-process
+                     popweb-name popweb-name
+                     popweb-internal-process-prog popweb-internal-process-args)))
+      (set-process-query-on-exit-flag popweb-internal-process nil))))
+
+(defun popweb-start-process ()
+  "Start POPWEB process if it isn't started."
+  (unless (popweb-epc-live-p popweb-epc-process)
+    ;; start epc server and set `popweb-server-port'
+    (popweb--start-epc-server)
+    (let* ((popweb-args (append
+                         (list popweb-python-file)
+                         (list (number-to-string popweb-server-port))
+                         )))
+
+      ;; Folow system DPI.
+      (popweb--follow-system-dpi)
+
+      ;; Set process arguments.
+      (if popweb-enable-debug
+          (progn
+            (setq popweb-internal-process-prog "gdb")
+            (setq popweb-internal-process-args (append (list "-batch" "-ex" "run" "-ex" "bt" "--args" popweb-python-command) popweb-args)))
+        (setq popweb-internal-process-prog popweb-python-command)
+        (setq popweb-internal-process-args popweb-args))
+
+      ;; Start python process.
+      (let ((process-connection-type (not (popweb--called-from-wsl-on-windows-p))))
+        (setq popweb-internal-process
+              (apply 'start-process
+                     popweb-name popweb-name
+                     popweb-internal-process-prog popweb-internal-process-args)))
+      (set-process-query-on-exit-flag popweb-internal-process nil))))
+
 (defun popweb--called-from-wsl-on-windows-p ()
   "Check whether popweb is called by Emacs on WSL and is running on Windows."
   (and (eq system-type 'gnu/linux)

--- a/popweb.py
+++ b/popweb.py
@@ -21,15 +21,15 @@
 
 # NOTE
 # QtWebEngine will throw error "ImportError: QtWebEngineWidgets must be imported before a QCoreApplication instance is created"
-from PyQt6.QtWebEngineWidgets import QWebEngineView
+from qtpy.QtWebEngineWidgets import QWebEngineView
 
-from PyQt6 import QtCore
-from PyQt6.QtGui import QColor
-from PyQt6.QtCore import QUrl, Qt, QEventLoop
-from PyQt6.QtNetwork import QNetworkProxy, QNetworkProxyFactory
-from PyQt6.QtWebEngineWidgets import QWebEngineView
-from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
-from PyQt6.QtWidgets import QWidget, QApplication, QVBoxLayout
+from qtpy import QtCore
+from qtpy.QtGui import QColor
+from qtpy.QtCore import QUrl, Qt, QEventLoop, Signal
+from qtpy.QtNetwork import QNetworkProxy, QNetworkProxyFactory
+from qtpy.QtWebEngineWidgets import QWebEngineView
+from qtpy.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
+from qtpy.QtWidgets import QWidget, QApplication, QVBoxLayout
 from epc.client import EPCClient
 from epc.server import ThreadingEPCServer
 import base64
@@ -43,7 +43,7 @@ import threading
 
 class PostGui(QtCore.QObject):
 
-    through_thread = QtCore.pyqtSignal(object, object)
+    through_thread = Signal(object, object)
 
     def __init__(self, inclass=True):
         super(PostGui, self).__init__()


### PR DESCRIPTION
[PySide6](https://wiki.qt.io/Qt_for_Python) is a python binding of Qt libraries, developed by the Qt company. It would be very neat if popweb can support both PyQt6 and PySide6.

In this PR, qtpy is introduced as a shim layer to support PyQt6 & PySide6.

# What's the difference between PySide6 & PyQt6

With qtpy, there's should be no big difference, a noticable change while porting to qtpy is: `QtCore.pyqtSignal` is renamed to `QtCore.Signal`, it follows the naming convention in `PySide6`.