### PR TITLE
Added customizability for the size of the url preview window 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ If you use Socks5 as a local proxy, one can set proxy type with:
 ```
 Popup windown scale to Emacs's.
 
+## Configure Url-Preivew popup window size
+```
+(setq popweb-url-web-window-width-scale 0.8)
+(setq popweb-url-web-window-height-scale 0.45)
+```
+Popup windown scale to Emacs's.
+
+
 ## Report bug
 Please use `emacs -q` and load a minimal setup with only popweb to verify that the bug is reproducible. If `emacs -q` works fine, probably something is wrong with your Emacs config.
 

--- a/extension/url-preview/popweb-url.el
+++ b/extension/url-preview/popweb-url.el
@@ -47,8 +47,8 @@
          (frame-y (cdr (frame-position)))
          (frame-w (frame-outer-width))
          (frame-h (frame-outer-height))
-         (width-scale 0.35)
-         (height-scale 0.5)
+         (width-scale 0.8)
+         (height-scale 0.45)
          (url (nth 0 info))
          )
     (popweb-call-async "call_module_method" popweb-url-module-path

--- a/extension/url-preview/popweb-url.el
+++ b/extension/url-preview/popweb-url.el
@@ -5,6 +5,13 @@
 
 (defvar popweb-url-web-window-visible-p nil)
 
+(defcustom popweb-url-web-window-width-scale 0.8
+  "The popup window's width scale of Emacs's"
+  :type '(float))
+
+(defcustom popweb-url-web-window-height-scale 0.45
+  "The popup window's height scale of Emacs's"
+  :type '(float))
 
 (defun popweb-url-local-file-url-completion (current-line)
   "If url is local file, complete it's absolute path"
@@ -47,8 +54,6 @@
          (frame-y (cdr (frame-position)))
          (frame-w (frame-outer-width))
          (frame-h (frame-outer-height))
-         (width-scale 0.8)
-         (height-scale 0.45)
          (url (nth 0 info))
          )
     (popweb-call-async "call_module_method" popweb-url-module-path
@@ -57,7 +62,8 @@
                         "url-preview"
                         x y x-offset y-offset
                         frame-x frame-y frame-w frame-h
-                        width-scale height-scale
+						popweb-url-web-window-width-scale
+						popweb-url-web-window-height-scale
                         url))
     (popweb-url-web-window-can-hide)))
 


### PR DESCRIPTION
I added 2 variables (`popweb-url-web-window-width-scale`, and `popweb-url-web-window-height-scale`) which allow you to change the width and height of the url preview popup window (defaults to `0.8` and `0.45` which is a `16x9` ratio).
Hopefully you guys find this feature useful.