### PR TITLE
Added option to allow absolute sizing of popup window for url preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,25 @@ If you use Socks5 as a local proxy, one can set proxy type with:
 (setq popweb-org-roam-link-popup-window-width-scale 0.8)
 (setq popweb-org-roam-link-popup-window-height-scale 0.5)
 ```
-Popup windown scale to Emacs's.
+Popup window scales to Emacs's.
 
 ## Configure Url-Preivew popup window size
+You can choose either scaled to emacs or in pixes by customizing
+```
+(setq popweb-url-web-window-size-use-absolute t)
+```
+### Scaled to emacs
 ```
 (setq popweb-url-web-window-width-scale 0.8)
 (setq popweb-url-web-window-height-scale 0.45)
 ```
-Popup windown scale to Emacs's.
+Popup window scales to Emacs's.
+### Absolute
+```
+(sqtq popweb-url-web-window-width-absolute 480)
+(sqtq popweb-url-web-window-height-absolute 270)
+```
+Popup window's size in pixels
 
 
 ## Report bug

--- a/extension/url-preview/popweb-url.el
+++ b/extension/url-preview/popweb-url.el
@@ -13,6 +13,19 @@
   "The popup window's height scale of Emacs's"
   :type '(float))
 
+(defcustom popweb-url-web-window-width-absolute 480
+  "The popup windows's absolute width in pixels"
+  :type '(int))
+
+(defcustom popweb-url-web-window-height-absolute 270
+  "The popup windows's absolute height in pixels"
+  :type '(int))
+
+(defcustom popweb-url-web-window-size-use-absolute t
+  "Wether to use absolute or relative size for the popup window"
+  :type '(bool))
+
+
 (defun popweb-url-local-file-url-completion (current-line)
   "If url is local file, complete it's absolute path"
   (let ((match-result (match-string 0 current-line))
@@ -64,6 +77,9 @@
                         frame-x frame-y frame-w frame-h
 						popweb-url-web-window-width-scale
 						popweb-url-web-window-height-scale
+						popweb-url-web-window-width-absolute
+						popweb-url-web-window-height-absolute
+						popweb-url-web-window-size-use-absolute
                         url))
     (popweb-url-web-window-can-hide)))
 

--- a/extension/url-preview/popweb-url.py
+++ b/extension/url-preview/popweb-url.py
@@ -1,9 +1,13 @@
 from PyQt6.QtCore import QUrl
 
-def pop_url_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url):
+def pop_url_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, width_absolute, height_absolute, use_absolute, url):
     web_window = popweb.get_web_window(module_name)
-    window_width = frame_w * width_scale
-    window_height = frame_h * height_scale
+    if not use_absolute:
+        window_width = frame_w * width_scale
+        window_height = frame_h * height_scale
+    else:
+        window_width = width_absolute
+        window_height = height_absolute
     window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
 
     web_window.webview.load(QUrl(url))


### PR DESCRIPTION
You can do this by changing the variables `popweb-url-web-window-size-use-absolute` (default value `t`), `popweb-url-web-window-width-absolute` (default value `480`), and `popweb-url-web-window-height-absolute` (default value `270`).