### PR TITLE
Hide existing popweb-dict window before new search

### DIFF
--- a/extension/dict/popweb-dict-bing.el
+++ b/extension/dict/popweb-dict-bing.el
@@ -122,12 +122,14 @@
 ;;;###autoload
 (defun popweb-dict-bing-input (&optional word)
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-bing-translate (list (or word (popweb-dict-prompt-input "Bing dict: "))))
   (add-hook 'post-command-hook #'popweb-dict-bing-web-window-hide-after-move))
 
 ;;;###autoload
 (defun popweb-dict-bing-pointer ()
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-bing-translate (list (popweb-dict-region-or-word)))
   (add-hook 'post-command-hook #'popweb-dict-bing-web-window-hide-after-move))
 

--- a/extension/dict/popweb-dict-youdao.el
+++ b/extension/dict/popweb-dict-youdao.el
@@ -127,12 +127,14 @@
 ;;;###autoload
 (defun popweb-dict-youdao-input (&optional word)
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-youdao-translate (list (or word (popweb-dict-prompt-input "Youdao dict: "))))
   (add-hook 'post-command-hook #'popweb-dict-youdao-web-window-hide-after-move))
 
 ;;;###autoload
 (defun popweb-dict-youdao-pointer ()
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-youdao-translate (list (popweb-dict-region-or-word)))
   (add-hook 'post-command-hook #'popweb-dict-youdao-web-window-hide-after-move))
 

--- a/extension/dict/popweb-dict-youglish.el
+++ b/extension/dict/popweb-dict-youglish.el
@@ -125,12 +125,14 @@
 ;;;###autoload
 (defun popweb-dict-youglish-input (&optional word)
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-youglish-translate (list (or word (popweb-dict-prompt-input "Youglish dict: "))))
   (add-hook 'post-command-hook #'popweb-dict-youglish-web-window-hide-after-move))
 
 ;;;###autoload
 (defun popweb-dict-youglish-pointer ()
   (interactive)
+  (popweb-dict-youdao-web-window-hide-after-move)
   (popweb-start 'popweb-dict-youglish-translate (list (popweb-dict-region-or-word)))
   (add-hook 'post-command-hook #'popweb-dict-youglish-web-window-hide-after-move))
 


### PR DESCRIPTION
For some reason, the popweb-dict window will not hide automatically
with `post-command-hook', So better to hide it before a new search. 

Close #20 .