### PR TITLE
popweb dict 支持传入 js 文件代码和 popweb-dict-*-input/pointer 传入参数以提供用户自定义功能

### DIFF
--- a/extension/dict/popweb-dict.el
+++ b/extension/dict/popweb-dict.el
@@ -127,7 +127,7 @@ Otherwise return word around point."
                                       (region-end))
     (thing-at-point 'word t)))
 
-(cl-defmacro popweb-dict-create (name url js-code)
+(cl-defmacro popweb-dict-create (name url js-code &optional js-file-code)
   (let* ((var-visible-p (intern (format "popweb-dict-%s-web-window-visible-p" name)))
          (var-say-word-process (intern (format "popweb-dict-%s-say-word-process" name)))
          (func-hide-after-move (intern (format "popweb-dict-%s-web-window-hide-after-move" name)))
@@ -165,7 +165,9 @@ Otherwise return word around point."
                 (height-scale 0.5)
                 (word (nth 0 info))
                 (url (format ,url word))
-                (js-code (format "try { %s } catch (err) { console.log(err.message) }" ,js-code)))
+                (js-code (format "try { %s } catch (err) { console.log(err.message) }" ,js-code))
+                (js-file-code (format "%s" ,js-file-code))
+                (args (nth 0 (cdr info))))
            (if popweb-dict-say-word-p (setq ,var-say-word-process (popweb-dict-say-word word)))
            (popweb-call-async "call_module_method" popweb-dict-module-path
                               "pop_translate_window"
@@ -174,7 +176,8 @@ Otherwise return word around point."
                                x y x-offset y-offset
                                frame-x frame-y frame-w frame-h
                                width-scale height-scale
-                               url js-code))
+                               url js-code
+                               js-file-code args))
            (funcall ',func-can-hide)))
 
        (defun ,func-pointer ()
@@ -183,12 +186,26 @@ Otherwise return word around point."
          (popweb-start ',func-translate (list (popweb-dict-region-or-word)))
          (add-hook 'post-command-hook #',func-hide-after-move))
 
-       (defun ,func-input (&optional word)
+       (defun ,func-input (&optional word &rest args)
          (interactive)
          (,func-hide-after-move)
-         (popweb-start ',func-translate (list (or word (popweb-dict-prompt-input (format "%s dict: " (capitalize ,name))))))
+         (popweb-start ',func-translate (list (or word (popweb-dict-prompt-input (format "%s dict: " (capitalize ,name)))) args))
          (add-hook 'post-command-hook #',func-hide-after-move))
        )))
+
+(defun popweb-join-dirs (root &rest dirs)
+  "Joins a series of directories together, like Python's os.path.join,
+  (dotemacs-joindirs \"/tmp\" \"a\" \"b\" \"c\") => /tmp/a/b/c"
+  (if (not dirs)
+      root
+    (apply 'popweb-join-dirs
+           (expand-file-name (car dirs) root)
+           (cdr dirs))))
+
+(defun popweb-load-js-code (file)
+  (with-temp-buffer
+    (insert-file-contents (popweb-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
+    (buffer-string)))
 
 (popweb-dict-create "bing"
                     "http://www.bing.com/dict/search?mkt=zh-cn&q=%s"

--- a/extension/dict/popweb-dict.el
+++ b/extension/dict/popweb-dict.el
@@ -193,12 +193,6 @@ Otherwise return word around point."
          (add-hook 'post-command-hook #',func-hide-after-move))
        )))
 
-(defun popweb-dict-join-dirs (root dir file)
-  (file-name-concat root dir file))
-
-(defun popweb-dict-js-file-path (file)
-  (popweb-dict-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
-
 (popweb-dict-create "bing"
                     "http://www.bing.com/dict/search?mkt=zh-cn&q=%s"
                     (concat

--- a/extension/dict/popweb-dict.el
+++ b/extension/dict/popweb-dict.el
@@ -127,7 +127,7 @@ Otherwise return word around point."
                                       (region-end))
     (thing-at-point 'word t)))
 
-(cl-defmacro popweb-dict-create (name url js-code &optional js-file-code)
+(cl-defmacro popweb-dict-create (name url js-code &optional js-file)
   (let* ((var-visible-p (intern (format "popweb-dict-%s-web-window-visible-p" name)))
          (var-say-word-process (intern (format "popweb-dict-%s-say-word-process" name)))
          (func-hide-after-move (intern (format "popweb-dict-%s-web-window-hide-after-move" name)))
@@ -166,7 +166,7 @@ Otherwise return word around point."
                 (word (nth 0 info))
                 (url (format ,url word))
                 (js-code (format "try { %s } catch (err) { console.log(err.message) }" ,js-code))
-                (js-file-code (format "%s" ,js-file-code))
+                (js-file (format "%s" ,js-file))
                 (args (nth 0 (cdr info))))
            (if popweb-dict-say-word-p (setq ,var-say-word-process (popweb-dict-say-word word)))
            (popweb-call-async "call_module_method" popweb-dict-module-path
@@ -177,7 +177,7 @@ Otherwise return word around point."
                                frame-x frame-y frame-w frame-h
                                width-scale height-scale
                                url js-code
-                               js-file-code args))
+                               js-file args))
            (funcall ',func-can-hide)))
 
        (defun ,func-pointer ()
@@ -193,19 +193,11 @@ Otherwise return word around point."
          (add-hook 'post-command-hook #',func-hide-after-move))
        )))
 
-(defun popweb-join-dirs (root &rest dirs)
-  "Joins a series of directories together, like Python's os.path.join,
-  (dotemacs-joindirs \"/tmp\" \"a\" \"b\" \"c\") => /tmp/a/b/c"
-  (if (not dirs)
-      root
-    (apply 'popweb-join-dirs
-           (expand-file-name (car dirs) root)
-           (cdr dirs))))
+(defun popweb-join-dirs (root dir file)
+  (file-name-concat root dir file))
 
-(defun popweb-load-js-code (file)
-  (with-temp-buffer
-    (insert-file-contents (popweb-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
-    (buffer-string)))
+(defun popweb-dict-js-file-path (file)
+  (popweb-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
 
 (popweb-dict-create "bing"
                     "http://www.bing.com/dict/search?mkt=zh-cn&q=%s"

--- a/extension/dict/popweb-dict.el
+++ b/extension/dict/popweb-dict.el
@@ -193,11 +193,11 @@ Otherwise return word around point."
          (add-hook 'post-command-hook #',func-hide-after-move))
        )))
 
-(defun popweb-join-dirs (root dir file)
+(defun popweb-dict-join-dirs (root dir file)
   (file-name-concat root dir file))
 
 (defun popweb-dict-js-file-path (file)
-  (popweb-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
+  (popweb-dict-join-dirs (file-name-directory popweb-dict-module-path) "js" file))
 
 (popweb-dict-create "bing"
                     "http://www.bing.com/dict/search?mkt=zh-cn&q=%s"

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -38,7 +38,10 @@ def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x,
 
 def read_js_content(js_file):
     ''' Read content of JavaScript(js) files.'''
-    try:
-        return open(js_file, "r").read()
-    except Exception as e:
-        print("An error occurred : %s\n" % e)
+     if os.path.exists(js_file):
+        with open(js_file, "r") as fp:
+             return(fp.read())
+     else:
+          print("File not found: %s\n" % js_file)
+          return("")
+

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -21,13 +21,15 @@
 
 from PyQt6.QtCore import QUrl
 
-def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url, loading_js_code):
+def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url, loading_js_code, js_file_code="", js_file_code_args=None):
     web_window = popweb.get_web_window(module_name)
     window_width = frame_w * width_scale
     window_height = frame_h * height_scale
     window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
 
     web_window.loading_js_code = loading_js_code
+    web_window.js_file_code = js_file_code
+    web_window.js_file_code_args = js_file_code_args
     web_window.webview.load(QUrl(url))
     web_window.update_theme_mode()
     web_window.resize(int(window_width), int(window_height))

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -28,7 +28,7 @@ def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x,
     window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
 
     web_window.loading_js_code = loading_js_code
-    web_window.js_file_code = read_js_content(js_file) or ""
+    web_window.js_file_code = read_js_content(js_file)
     web_window.js_file_code_args = js_file_code_args
     web_window.webview.load(QUrl(url))
     web_window.update_theme_mode()

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -21,17 +21,24 @@
 
 from PyQt6.QtCore import QUrl
 
-def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url, loading_js_code, js_file_code="", js_file_code_args=None):
+def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame_y, frame_w, frame_h, width_scale, height_scale, url, loading_js_code, js_file="", js_file_code_args=None):
     web_window = popweb.get_web_window(module_name)
     window_width = frame_w * width_scale
     window_height = frame_h * height_scale
     window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
 
     web_window.loading_js_code = loading_js_code
-    web_window.js_file_code = js_file_code
+    web_window.js_file_code = read_js_content(js_file) or ""
     web_window.js_file_code_args = js_file_code_args
     web_window.webview.load(QUrl(url))
     web_window.update_theme_mode()
     web_window.resize(int(window_width), int(window_height))
     web_window.move(int(window_x), int(window_y))
     web_window.popup()
+
+def read_js_content(js_file):
+    ''' Read content of JavaScript(js) files.'''
+    try:
+        return open(js_file, "r").read()
+    except Exception as e:
+        print("An error occurred : %s\n" % e)

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -38,10 +38,12 @@ def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x,
 
 def read_js_content(js_file):
     ''' Read content of JavaScript(js) files.'''
-     if os.path.exists(js_file):
+    import os
+    if os.path.exists(js_file):
         with open(js_file, "r") as fp:
              return(fp.read())
-     else:
+    else:
           print("File not found: %s\n" % js_file)
           return("")
+
 

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -41,9 +41,7 @@ def read_js_content(js_file):
     import os
     if os.path.exists(js_file):
         with open(js_file, "r") as fp:
-             return(fp.read())
+            return(fp.read())
     else:
-          print("File not found: %s\n" % js_file)
-          return("")
-
-
+        print("File not found: %s\n" % js_file)
+        return("")

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -41,7 +41,7 @@ def read_js_content(js_file):
     import os
     if os.path.exists(js_file):
         with open(js_file, "r") as fp:
-            return(fp.read())
+            return fp.read()
     else:
         print("File not found: %s\n" % js_file)
-        return("")
+        return ""

--- a/popweb.py
+++ b/popweb.py
@@ -192,6 +192,8 @@ class WebWindow(QWidget):
             self.zoom_factor = self.zoom_factor * 2
 
         self.loading_js_code = ""
+        self.js_file_code = ""
+        self.js_file_code_args = None
         self.load_finish_callback = None
 
         self.dark_mode_js = open(os.path.join(os.path.dirname(__file__), "darkreader.js")).read()
@@ -255,6 +257,9 @@ class WebWindow(QWidget):
             self.enable_dark_mode()
 
     def execute_load_finish_js_code(self):
+        if self.js_file_code != "":
+            js_code = self.js_file_code + "({0});".format(self.js_file_code_args)
+            self.webview.page().runJavaScript(js_code)
         if self.load_finish_callback is not None:
             self.load_finish_callback()
 
@@ -410,7 +415,7 @@ class POPWEB(object):
             web_window = self.web_window_dict[module_name]
             web_window.hide()
             web_window.webview.load(QUrl(""))
-            
+
             if hasattr(web_window, "developer_tools_view"):
                 web_window.developer_tools_view.hide()
 

--- a/popweb.py
+++ b/popweb.py
@@ -258,7 +258,7 @@ class WebWindow(QWidget):
 
     def execute_load_finish_js_code(self):
         if self.js_file_code != "":
-            js_code = self.js_file_code + "({0});".format(self.js_file_code_args)
+            js_code = self.js_file_code + "({0});".format(str(self.js_file_code_args or ""))
             self.webview.page().runJavaScript(js_code)
         if self.load_finish_callback is not None:
             self.load_finish_callback()


### PR DESCRIPTION
希望支持该特性的原因是我通过 https://dict.eudic.net/liju/en/revolutionary 欧路例句查询某个英语单词的例句。

并且希望能够把原声例句保存到 Anki 中，以便以后方便练习听力，复习单词。

在网页中提取例句，原声音频，发送给 Anki 创建卡片，需要较长的代码，所以希望能加载文件中的代码，和传入参数执行。
（在我的设想，该参数可以是在 emacs 中调用 popweb-dict-eudic-liju-point 光标下的单词所在的句子。）

将所需的 js 文件放在 popweb/extension/dict/js/eudic-liju.js 中
通过 
```
(popweb-dict-create "eudic-liju"
                    "https://dict.eudic.net/liju/en/%s"
                    ""
                    (popweb-load-js-code "eudic-liju.js")
                    )
``` 
创建 popweb-dict-eudic-liju-input 命令，同时传入 js 代码。

通过
```
(defun my-popweb-dict-eudic-liju-search-at-point ()
      (interactive)
      (if (display-graphic-p)
          (popweb-dict-eudic-liju-input nil (lc-corpus--sentence))))
```
`my-popweb-dict-eudic-liju-search-at-point` 获取光标下的单词，和 `(lc-corpus--sentence)` 获取到的单词所在的句子。

在查询单词例句的网页上，点击自己中意的例句后的发送 Anki 图标，发送欧路例句，原声音频，和通过参数形式传入的单词所在的上下文句子，发送到 Anki 中。（这部分的功能是用户在 eudic-liju.js 中自定义的）

演示图如下：

查询 `That success has been achieved with the help of assembling an all-star squad with some of the best players in the world.` success 单词的例句。
点击原声例句 `Perseverance and determination contribute greatly to one's success.毅力和决心是学生成功的关键。` 后的发送图标，完成流程。

![截屏2023-02-08 02 06 34](https://user-images.githubusercontent.com/20676402/217329570-cdd36bec-5a2a-4374-85e5-f7eb9d23125f.png)

Anki 卡片中有查询单词的时的上下文句子，欧路原声例句，原声音频。

![截屏2023-02-08 02 07 18](https://user-images.githubusercontent.com/20676402/217329599-5dc2437b-d434-4ff7-aa6c-bf03fbda94f2.png)


