### PR TITLE
support import cookie from other browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ I consider `popweb` to be a sister project, and a lightweight version of EAF tha
 ## Installation
 1. Install PyQt6: ```pip install PyQt6 PyQt6-Qt6 PyQt6-sip PyQt6-WebEngine PyQt6-WebEngine-Qt6```
 2. Install [python-epc](https://github.com/tkf/python-epc): ```pip install epc```
-3. Clone or download this repository (path of the folder is the `<path-to-popweb>` used below).
-4. In your `~/.emacs`, add the following lines:
+3. Install [browser_cookie3](https://github.com/borisbabic/browser_cookie3)(optional, for import cookies from browser): ```pip install browser_cookie3```
+4. Clone or download this repository (path of the folder is the `<path-to-popweb>` used below).
+5. In your `~/.emacs`, add the following lines:
 ```elisp
 (add-to-list 'load-path "<path-to-popweb>") ; add popweb to your load-path
 
@@ -38,6 +39,7 @@ I consider `popweb` to be a sister project, and a lightweight version of EAF tha
 * `M-x popweb-org-roam-link-show`: Preview Org-Roam ID link or footnote link at point.
 * `M-x popweb-org-roam-link-preview-select` Select one of all Org-Roam ID links and footnote links in a Org-mode buffer by ivy, then preview the content of link.
 * `M-x popweb-org-roam-node-preview-select` Select one Org-Roam node by ivy, then hit `C-M-m ivy-call` to preview the content of node without exit ivy windown.
+* `M-x popweb-import-browser-cookies` Import cookies for the specified domain name.
 ## Screenshots
 ### LaTeX Preview
 <p align="center">

--- a/extension/dict/popweb-dict.py
+++ b/extension/dict/popweb-dict.py
@@ -30,7 +30,7 @@ def pop_translate_window(popweb, module_name, x, y, x_offset, y_offset, frame_x,
     web_window.loading_js_code = loading_js_code
     web_window.js_file_code = read_js_content(js_file)
     web_window.js_file_code_args = js_file_code_args
-    web_window.webview.load(QUrl(url))
+    web_window.webview.setUrl(QUrl(url))
     web_window.update_theme_mode()
     web_window.resize(int(window_width), int(window_height))
     web_window.move(int(window_x), int(window_y))

--- a/extension/url-preview/popweb-url.py
+++ b/extension/url-preview/popweb-url.py
@@ -10,7 +10,7 @@ def pop_url_window(popweb, module_name, x, y, x_offset, y_offset, frame_x, frame
         window_height = height_absolute
     window_x, window_y = popweb.adjust_render_pos(x + x_offset, y + y_offset, x_offset, y_offset, window_width, window_height, frame_x, frame_y, frame_w, frame_h)
 
-    web_window.webview.load(QUrl(url))
+    web_window.webview.setUrl(QUrl(url))
     web_window.update_theme_mode()
     web_window.resize(int(window_width), int(window_height))
     web_window.move(int(window_x), int(window_y))

--- a/popweb.el
+++ b/popweb.el
@@ -192,6 +192,11 @@ Turn on this option will improve start speed."
   "Zoom factor for web page."
   :type 'integer)
 
+(defcustom popweb-config-location (expand-file-name (locate-user-emacs-file "popweb/"))
+  "Directory where popweb will store configuration files."
+  :type 'directory)
+
+
 (defun popweb-call-async (method &rest args)
   "Call Python EPC function METHOD and ARGS asynchronously."
   (popweb-deferred-chain
@@ -378,6 +383,16 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
             (popweb-color-int-to-hex (nth 0 components))
             (popweb-color-int-to-hex (nth 1 components))
             (popweb-color-int-to-hex (nth 2 components)))))
+
+
+(defun popweb-import-browser-cookies (browser domain-name)
+  "Import cookies for the specified domain name."
+  (interactive (list (completing-read "Which browser ? "
+                                      '("chrome" "chromium" "opera" "opera_gx" "brave" "edge" "vivaldi" "firefox" "safari") nil t)
+                     (read-string "Domain name: ")))
+  (popweb-start #'(lambda (&rest _)
+                    (popweb-call-async "import_browser_cookies" browser domain-name)) nil))
+
 
 (provide 'popweb)
 

--- a/popweb.py
+++ b/popweb.py
@@ -25,9 +25,9 @@ from PyQt6.QtWebEngineWidgets import QWebEngineView
 
 from PyQt6 import QtCore
 from PyQt6.QtGui import QColor
-from PyQt6.QtCore import QUrl, Qt, QEventLoop
-from PyQt6.QtNetwork import QNetworkProxy, QNetworkProxyFactory
-from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
+from PyQt6.QtCore import QDateTime, QUrl, Qt, QEventLoop
+from PyQt6.QtNetwork import QNetworkCookie, QNetworkProxy, QNetworkProxyFactory
+from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings, QWebEngineProfile
 from PyQt6.QtWidgets import QWidget, QApplication, QVBoxLayout
 from epc.client import EPCClient
 from epc.server import ThreadingEPCServer
@@ -150,6 +150,188 @@ def get_emacs_func_result(method_name, args):
         result = epc_client.call_sync("eval-in-emacs", args)
         return result if result != [] else False
 
+emacs_config_dir = ""
+
+def get_emacs_config_dir():
+    import os
+
+    global emacs_config_dir
+
+    if emacs_config_dir == "":
+        emacs_config_dir = os.path.join(os.path.expanduser(get_emacs_var("popweb-config-location")), '')
+
+    if not os.path.exists(emacs_config_dir):
+        os.makedirs(emacs_config_dir)
+
+    return emacs_config_dir
+
+def touch(path):
+    import os
+
+    if not os.path.exists(path):
+        basedir = os.path.dirname(path)
+
+        if not os.path.exists(basedir):
+            os.makedirs(basedir)
+
+        with open(path, 'a'):
+            os.utime(path)
+
+class CookiesManager(object):
+
+    def __init__(self, browser_view):
+        self.browser_view = browser_view
+
+        self.cookies_dir = self.get_cookies_dir()
+
+        # Both session and persistent cookies are stored in memory
+        self.browser_view.page().profile().setPersistentCookiesPolicy(QWebEngineProfile.PersistentCookiesPolicy.NoPersistentCookies)
+
+        self.cookie_store = self.browser_view.page().profile().cookieStore()
+
+        self.cookie_store.cookieAdded.connect(self.add_cookie)      # save cookie to disk when captured cookieAdded signal
+        self.cookie_store.cookieRemoved.connect(self.remove_cookie) # remove cookie stored on disk when captured cookieRemoved signal
+        self.browser_view.loadStarted.connect(self.load_cookie)     # load disk cookie to QWebEngineView instance when page start load
+
+    @classmethod
+    def get_cookies_dir(cls):
+        return os.path.join(get_emacs_config_dir(), "browser", "cookies")
+
+    @classmethod
+    def add_cookie(cls, cookie):
+        '''Store cookie on disk.'''
+        cookie_domain = cookie.domain()
+        if not cookie.isSessionCookie():
+            cookie_file = os.path.join(cls.get_cookies_dir(), cookie_domain, cls._generate_cookie_filename(cookie))
+            touch(cookie_file)
+
+            # Save newest cookie to disk.
+            with open(cookie_file, "wb") as f:
+                f.write(cookie.toRawForm())
+
+    def load_cookie(self):
+        ''' Load cookie file from disk.'''
+        if not os.path.exists(self.cookies_dir):
+            return
+
+        all_cookies_domain = os.listdir(self.cookies_dir)
+        for domain in filter(self.domain_matching, all_cookies_domain):
+            from PyQt6.QtNetwork import QNetworkCookie
+
+            domain_dir = os.path.join(self.cookies_dir, domain)
+
+            for cookie_file in os.listdir(domain_dir):
+                with open(os.path.join(domain_dir, cookie_file), "rb") as f:
+                    for cookie in QNetworkCookie.parseCookies(f.read()):
+                        if not domain.startswith('.'):
+                            if self.browser_view.url().host() == domain:
+                                # restore host-only cookie
+                                cookie.setDomain('')
+                                self.cookie_store.setCookie(cookie, self.browser_view.url())
+                        else:
+                            self.cookie_store.setCookie(cookie)
+
+    def remove_cookie(self, cookie):
+        ''' Delete cookie file.'''
+        if not cookie.isSessionCookie():
+            cookie_file = os.path.join(self.cookies_dir, cookie.domain(), self._generate_cookie_filename(cookie))
+
+            if os.path.exists(cookie_file):
+                os.remove(cookie_file)
+
+    def delete_all_cookies(self):
+        ''' Simply delete all cookies stored on memory and disk.'''
+        self.cookie_store.deleteAllCookies()
+        if os.path.exists(self.cookies_dir):
+            import shutil
+            shutil.rmtree(self.cookies_dir)
+
+    def delete_cookie(self):
+        ''' Delete all cookie used by current site except session cookies.'''
+        from PyQt6.QtNetwork import QNetworkCookie
+        import shutil
+
+        cookies_domain = os.listdir(self.cookies_dir)
+
+        for domain in filter(self.get_relate_domains, cookies_domain):
+            domain_dir = os.path.join(self.cookies_dir, domain)
+
+            for cookie_file in os.listdir(domain_dir):
+                with open(os.path.join(domain_dir, cookie_file), "rb") as f:
+                    for cookie in QNetworkCookie.parseCookies(f.read()):
+                        self.cookie_store.deleteCookie(cookie)
+            shutil.rmtree(domain_dir)
+
+    def domain_matching(self, cookie_domain):
+        ''' Check if a given cookie's domain is matching for host string.'''
+        return True
+        cookie_is_hostOnly = True
+        if cookie_domain.startswith('.'):
+            # get rid of prefixing dot when matching domains
+            cookie_domain = cookie_domain[1:]
+            cookie_is_hostOnly = False
+
+        host_string = self.browser_view.url().host()
+        if cookie_domain == host_string:
+            # The domain string and the host string are identical
+            return True
+
+        if len(host_string) < len(cookie_domain):
+            # For obvious reasons, the host string cannot be a suffix if the domain
+            # is shorter than the domain string
+            return False
+
+        if host_string.endswith(cookie_domain) and host_string[:-len(cookie_domain)][-1] == '.' and not cookie_is_hostOnly:
+            # The domain string should be a suffix of the host string,
+            # The last character of the host string that is not included in the
+            # domain string should be a %x2E (".") character.
+            # and cookie domain not have prefixing dot (host-only cookie is not for subdomains)
+            return True
+
+        return False
+
+    def get_relate_domains(self, cookie_domain):
+        ''' Check whether the cookie domain is located under the same root host as the current URL host.'''
+        import tld, re
+
+        host_string = self.browser_view.url().host()
+
+        if cookie_domain.startswith('.'):
+            cookie_domain = cookie_domain[1:]
+
+        base_domain = tld.get_fld(host_string, fix_protocol=True, fail_silently=True)
+
+        if not base_domain:
+            # check whether host string is an IP address
+            if re.compile('^((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)$').match(host_string) and host_string == cookie_domain:
+                return True
+            return  False
+
+        if cookie_domain == base_domain:
+            return True
+
+        if cookie_domain.endswith(base_domain) and cookie_domain[:-len(base_domain)][-1] == '.':
+            return True
+
+        return False
+
+    @classmethod
+    def _generate_cookie_filename(cls, cookie):
+        ''' Gets the name of the cookie file stored on the hard disk.'''
+        name = cookie.name().data().decode("utf-8")
+        domain = cookie.domain()
+        if os.name == "nt":
+            encode_path = cookie.path().encode("utf-8").hex()
+        else:
+            encode_path = cookie.path().replace("/", "|")
+
+        return name + "+" + domain + "+" + encode_path
+
+class WebView(QWebEngineView):
+    def __init__(self):
+        super(QWebEngineView, self).__init__()
+        self.cookies_manager = CookiesManager(self)
+
 class BrowserPage(QWebEnginePage):
     def __init__(self):
         QWebEnginePage.__init__(self)
@@ -199,8 +381,7 @@ class WebWindow(QWidget):
         self.dark_mode_js = open(os.path.join(os.path.dirname(__file__), "darkreader.js")).read()
 
         self.update_theme_mode()
-
-        self.webview = QWebEngineView()
+        self.webview = WebView()
         self.web_page = BrowserPage()
         self.webview.setPage(self.web_page)
         self.web_page.setBackgroundColor(QColor(get_emacs_func_result("popweb-get-theme-background", [])))
@@ -418,6 +599,25 @@ class POPWEB(object):
 
             if hasattr(web_window, "developer_tools_view"):
                 web_window.developer_tools_view.hide()
+
+    def import_browser_cookies(self, browser, domain_name):
+        try:
+            import browser_cookie3
+            cookiejar = getattr(browser_cookie3, browser)(domain_name=domain_name)
+            if cookiejar is None:
+                print("Import cookie failed!")
+                return
+
+            for cookie in cookiejar:
+                qt_cookie = QNetworkCookie(cookie.name.encode(), cookie.value.encode())
+                qt_cookie.setDomain(cookie.domain)
+                qt_cookie.setSecure(cookie.secure)
+                qt_cookie.setPath(cookie.path)
+                qt_cookie.setExpirationDate(QDateTime.fromSecsSinceEpoch(0 if cookie.expires is None else cookie.expires))
+                CookiesManager.add_cookie(qt_cookie)
+        except:
+            import traceback
+            traceback.print_exc()
 
     def cleanup(self):
         '''Do some cleanup before exit python process.'''


### PR DESCRIPTION
1. 让 popweb 支持 cookie
2. 提供一个函数从其它浏览器导入指定网站的cookie

从浏览器登录某个网站，然后在 popweb 中导入这个网站的 cookie ，popweb 访问这个网站也是登录状态。

比如欧陆词典登录后可以将查询的单词加入生词本，方便和手机同步

![image](https://user-images.githubusercontent.com/30917129/218263376-79cad46a-79f6-473e-a34a-91b18f6965bc.png)
